### PR TITLE
newt のつなぎこみを行う

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@types/react-dom": "18.0.10",
         "eslint": "8.33.0",
         "eslint-config-next": "13.1.6",
+        "newt-client-js": "^3.2.4",
         "next": "13.1.6",
         "react": "18.2.0",
         "react-dom": "18.2.0",
@@ -661,6 +662,23 @@
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "node_modules/axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
       }
     },
     "node_modules/axobject-query": {
@@ -1561,6 +1579,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -2067,6 +2104,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
@@ -2367,6 +2415,19 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "node_modules/newt-client-js": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/newt-client-js/-/newt-client-js-3.2.4.tgz",
+      "integrity": "sha512-BeF3ddfd5DzXV2qOFwciiNzKqP+DpaITVRcRks5tAoWwpFXwtKxG/bZJoZH/6lJkEH5kuuN2dYM1+BY/3dMVpg==",
+      "dependencies": {
+        "axios": "^0.26.1",
+        "axios-retry": "^3.2.4",
+        "qs": "^6.10.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/next": {
       "version": "13.1.6",
@@ -2746,6 +2807,20 @@
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/queue-microtask": {
@@ -3742,6 +3817,23 @@
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.6.3.tgz",
       "integrity": "sha512-/BQzOX780JhsxDnPpH4ZiyrJAzcd8AfzFPkv+89veFSr1rcMjuq2JDCwypKaPeB6ljHp9KjXhPpjgCvQlWYuqg=="
     },
+    "axios": {
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
+      "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
+      "requires": {
+        "follow-redirects": "^1.14.8"
+      }
+    },
+    "axios-retry": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.4.0.tgz",
+      "integrity": "sha512-VdgaP+gHH4iQYCCNUWF2pcqeciVOdGrBBAYUfTY+wPcO5Ltvp/37MLFNCmJKo7Gj3SHvCSdL8ouI1qLYJN3liA==",
+      "requires": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
     "axobject-query": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-3.1.1.tgz",
@@ -4423,6 +4515,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
+    },
     "for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4758,6 +4855,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+    },
     "is-set": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.2.tgz",
@@ -4976,6 +5078,16 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="
+    },
+    "newt-client-js": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/newt-client-js/-/newt-client-js-3.2.4.tgz",
+      "integrity": "sha512-BeF3ddfd5DzXV2qOFwciiNzKqP+DpaITVRcRks5tAoWwpFXwtKxG/bZJoZH/6lJkEH5kuuN2dYM1+BY/3dMVpg==",
+      "requires": {
+        "axios": "^0.26.1",
+        "axios-retry": "^3.2.4",
+        "qs": "^6.10.1"
+      }
     },
     "next": {
       "version": "13.1.6",
@@ -5208,6 +5320,14 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
       "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA=="
+    },
+    "qs": {
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.0.tgz",
+      "integrity": "sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==",
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
     },
     "queue-microtask": {
       "version": "1.2.3",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@types/react-dom": "18.0.10",
     "eslint": "8.33.0",
     "eslint-config-next": "13.1.6",
+    "newt-client-js": "^3.2.4",
     "next": "13.1.6",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,22 @@
-import styles from "./page.module.css";
+import Link from "next/link";
+import { getPosts } from "../lib/newt";
 
 // const inter = Inter({ subsets: ['latin'] })
 
-export default function Home() {
-  return <h1 className={styles.test}>top</h1>;
+export default async function Home() {
+  // server component なので直接書いてOK。クライアントでは実行されない。
+  const posts = await getPosts();
+  return (
+    <main>
+      <ul>
+        {posts.map((article) => {
+          return (
+            <li key={article._id}>
+              <Link href={`posts/${article.slug}`}>{article.title}</Link>
+            </li>
+          );
+        })}
+      </ul>
+    </main>
+  );
 }

--- a/src/app/posts/[slug]/page.tsx
+++ b/src/app/posts/[slug]/page.tsx
@@ -1,14 +1,34 @@
+import { getPostBySlug } from "@/lib/newt";
+
 interface Props {
   params: {
     slug: string;
   };
 }
 
-export default function Post(props: Props) {
+// todo: app dir を使っていると next build でエラーになるため、必要かどうか確かめる
+// export const getStaticPaths = async () => {
+//   console.log("getStaticPaths");
+//   const posts = await getPosts();
+//   return {
+//     paths: posts.map((post) => ({
+//       params: {
+//         slug: post.slug,
+//       },
+//     })),
+//     fallback: false,
+//   };
+// };
+
+export default async function Post(props: Props) {
+  const post = await getPostBySlug(props.params.slug);
+  // todo: getStaticPaths で `paths` に返されたページをすべて事前生成しており、
+  // fallback で404を返せるのであればこの if 文は消したい。方法を調べる
+  if (post === null) return <p>記事は存在しません。</p>;
   return (
-    <>
-      <h1>記事</h1>
-      <p>id: {props.params.slug}</p>
-    </>
+    <main>
+      <h1>{post.title}</h1>
+      <div dangerouslySetInnerHTML={{ __html: post.body }} />
+    </main>
   );
 }

--- a/src/lib/newt.ts
+++ b/src/lib/newt.ts
@@ -1,0 +1,20 @@
+// ref: https://www.newt.so/docs/tutorials/get-contents-in-nextjs
+import type { Post } from "@/types/Post";
+import { createClient } from "newt-client-js";
+
+const client = createClient({
+  spaceUid: process.env.NEWT_SPACE_UID + "",
+  token: process.env.NEWT_CDN_API_TOKEN + "",
+  apiType: "cdn",
+});
+
+export const getPosts = async () => {
+  const { items } = await client.getContents<Post>({
+    appUid: "blog2",
+    modelUid: "post",
+    query: {
+      select: ["_id", "title", "slug", "body"],
+    },
+  });
+  return items;
+};

--- a/src/lib/newt.ts
+++ b/src/lib/newt.ts
@@ -18,3 +18,15 @@ export const getPosts = async () => {
   });
   return items;
 };
+
+export const getPostBySlug = async (slug: string) => {
+  const article = await client.getFirstContent<Post>({
+    appUid: "blog2",
+    modelUid: "post",
+    query: {
+      slug,
+      select: ["_id", "title", "slug", "body"],
+    },
+  });
+  return article;
+};

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -1,0 +1,7 @@
+// newt の型
+export interface Post {
+  _id: string;
+  title: string;
+  slug: string;
+  body: string;
+}


### PR DESCRIPTION
ひとまず[チュートリアル](https://www.newt.so/docs/tutorials/get-contents-in-nextjs)に沿って。

- トップページに記事一覧を表示
- 記事ページ作成

わからないこと

- getStaticPaths の要不要
  - おそらく SSG 時に、動的なページぶんだけ静的ファイルを生成するために必要なもの
  - ということは、Vercel でISRをする場合は不要？
- getStaticPaths で fallback: false を返すと記事が存在しなかった場合に自動で 404 へのルーティングを行ってくれるようだが、app dir を使っている場合は npm run build 時に getStaticPaths が使えないため、どうしたらいいか？
  - 今は if (post === null) を書くことで型エラーを回避している...