### PR TITLE
デフォルトmargin/paddingのリセットをやめる

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,3 @@
 * {
   box-sizing: border-box;
-  padding: 0;
-  margin: 0;
 }


### PR DESCRIPTION
記事本文のHTMLタグを、正式にスタイリングするまで初期状態で見やすくするため